### PR TITLE
feat: 이미지 저장 및 조회 기능 구현 + 회원 프로필 이미지 업로드 기능까지

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     // jwt

--- a/src/docs/asciidoc/image.adoc
+++ b/src/docs/asciidoc/image.adoc
@@ -1,0 +1,9 @@
+[[interest]]
+
+== 이미지
+
+=== 이미지 업로드
+
+만약 특정 이미지 업로드 API가 존재하면 해당 API를 사용해주세요.
+
+operation::image/upload/success[snippets='http-request,http-response,request-parts,response-fields']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -10,4 +10,5 @@
 include::auth.adoc[]
 include::member.adoc[]
 include::interest.adoc[]
+include::image.adoc[]
 include::errorCode.adoc[]

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -8,3 +8,7 @@ operation::member/signup/success[snippets='http-request,http-response,request-fi
 === 닉네임 중복확인
 
 operation::member/duplicate-nickname-check/success[snippets='http-request,http-response,path-parameters,response-fields']
+
+=== 회원 프로필 이미지 업로드
+
+operation::member/upload-profile-images/success[snippets='http-request,http-response,request-parts,response-fields']

--- a/src/main/java/com/project1hour/api/core/application/member/MemberService.java
+++ b/src/main/java/com/project1hour/api/core/application/member/MemberService.java
@@ -1,12 +1,15 @@
 package com.project1hour.api.core.application.member;
 
 import com.project1hour.api.core.domain.member.Member;
+import com.project1hour.api.core.implement.image.ImageProcessor;
 import com.project1hour.api.core.implement.member.MemberInterestProcessor;
 import com.project1hour.api.core.implement.member.MemberProcessor;
 import com.project1hour.api.core.implement.member.MemberReader;
 import com.project1hour.api.core.implement.member.dto.NewMemberInfo;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +18,7 @@ public class MemberService {
     private final MemberReader memberReader;
     private final MemberProcessor memberProcessor;
     private final MemberInterestProcessor memberInterestProcessor;
+    private final ImageProcessor imageProcessor;
 
     public void signUp(final Long authenticatedMemberId, final NewMemberInfo newMemberInfo) {
         Member member = memberReader.read(authenticatedMemberId);
@@ -24,5 +28,13 @@ public class MemberService {
 
     public boolean isDuplicate(final String nickname) {
         return memberReader.isExistsNickname(nickname);
+    }
+
+    public List<String> uploadProfileImages(final Long memberId, final List<MultipartFile> images) {
+        Member member = memberReader.read(memberId);
+        List<String> imageUrls = imageProcessor.uploadProfileImages(member, images);
+        memberProcessor.updateNewProfileImages(member, imageUrls);
+
+        return imageUrls;
     }
 }

--- a/src/main/java/com/project1hour/api/core/domain/auth/AuthProvider.java
+++ b/src/main/java/com/project1hour/api/core/domain/auth/AuthProvider.java
@@ -24,6 +24,7 @@ public class AuthProvider {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "auth_provider_id")
     private Long id;
 
     private String email;

--- a/src/main/java/com/project1hour/api/core/domain/image/ImageFile.java
+++ b/src/main/java/com/project1hour/api/core/domain/image/ImageFile.java
@@ -1,0 +1,82 @@
+package com.project1hour.api.core.domain.image;
+
+import com.project1hour.api.global.advice.BadRequestException;
+import com.project1hour.api.global.advice.ErrorCode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.Getter;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+public class ImageFile {
+
+    private static final Pattern IMAGE_EXTENSION_REGX = Pattern.compile("^(png|jpeg|jpg|svg)$");
+
+    private final String originalFileName;
+    private final String contentType;
+    private final String extension;
+    private final InputStream imageInputStream;
+
+    public ImageFile(final String originalFileName, final String contentType, final String extension,
+                     final InputStream imageInputStream) {
+        this.originalFileName = originalFileName;
+        this.contentType = contentType;
+        this.extension = extension;
+        this.imageInputStream = imageInputStream;
+    }
+
+    public static ImageFile from(final MultipartFile multipartFile) {
+        validateNullFile(multipartFile);
+        validateEmptyFile(multipartFile);
+        validateFileName(multipartFile);
+        validateExtension(multipartFile);
+
+        try {
+            return new ImageFile(
+                    multipartFile.getOriginalFilename(),
+                    multipartFile.getContentType(),
+                    StringUtils.getFilenameExtension(multipartFile.getOriginalFilename()),
+                    multipartFile.getInputStream()
+            );
+        } catch (IOException e) {
+            throw new BadRequestException("이미지를 읽을 수 없습니다.", ErrorCode.CAN_NOT_READ_IMAGE);
+        }
+    }
+
+    private static void validateNullFile(final MultipartFile multipartFile) {
+        if (multipartFile == null) {
+            throw new BadRequestException("이미지로 NULL값이 들어올 수 없습니다.", ErrorCode.NULL_IMAGE);
+        }
+    }
+
+    private static void validateEmptyFile(final MultipartFile multipartFile) {
+        if (multipartFile.getSize() == 0) {
+            throw new BadRequestException("이미지 파일이 비어있을 수 없습니다.", ErrorCode.EMPTY_IMAGE);
+        }
+    }
+
+    private static void validateFileName(final MultipartFile multipartFile) {
+        if (Objects.requireNonNull(multipartFile.getOriginalFilename()).isEmpty()) {
+            throw new BadRequestException("이미지의 이름이 NULL이거나 비어있을 수 없습니다.", ErrorCode.INVALID_IMAGE_NAME);
+        }
+    }
+
+    private static void validateExtension(final MultipartFile multipartFile) {
+        String extension = StringUtils.getFilenameExtension(multipartFile.getOriginalFilename());
+        Matcher matcher = IMAGE_EXTENSION_REGX.matcher(extension);
+
+        String message = String.format("불가능한 이미지 확장자 입니다. extension = %s", extension);
+        if (!matcher.matches()) {
+            throw new BadRequestException(message, ErrorCode.INVALID_IMAGE_EXTENSION);
+        }
+    }
+
+    public String randomName() {
+        return UUID.randomUUID() + "." + extension;
+    }
+}

--- a/src/main/java/com/project1hour/api/core/domain/image/ImageFile.java
+++ b/src/main/java/com/project1hour/api/core/domain/image/ImageFile.java
@@ -8,27 +8,12 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import lombok.Getter;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
-@Getter
-public class ImageFile {
+public record ImageFile(String originalFileName, String contentType, String extension, InputStream imageInputStream) {
 
     private static final Pattern IMAGE_EXTENSION_REGX = Pattern.compile("^(png|jpeg|jpg|svg)$");
-
-    private final String originalFileName;
-    private final String contentType;
-    private final String extension;
-    private final InputStream imageInputStream;
-
-    public ImageFile(final String originalFileName, final String contentType, final String extension,
-                     final InputStream imageInputStream) {
-        this.originalFileName = originalFileName;
-        this.contentType = contentType;
-        this.extension = extension;
-        this.imageInputStream = imageInputStream;
-    }
 
     public static ImageFile from(final MultipartFile multipartFile) {
         validateNullFile(multipartFile);

--- a/src/main/java/com/project1hour/api/core/domain/image/ImageUploader.java
+++ b/src/main/java/com/project1hour/api/core/domain/image/ImageUploader.java
@@ -1,0 +1,6 @@
+package com.project1hour.api.core.domain.image;
+
+public interface ImageUploader {
+
+    String upload(ImageFile imageFile);
+}

--- a/src/main/java/com/project1hour/api/core/domain/member/Member.java
+++ b/src/main/java/com/project1hour/api/core/domain/member/Member.java
@@ -4,6 +4,7 @@ import com.project1hour.api.core.domain.member.profileinfo.Birthday;
 import com.project1hour.api.core.domain.member.profileinfo.Gender;
 import com.project1hour.api.core.domain.member.profileinfo.Mbti;
 import com.project1hour.api.core.domain.member.profileinfo.Nickname;
+import com.project1hour.api.core.domain.member.profileinfo.ProfileImage;
 import com.project1hour.api.global.domain.CommonField;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -15,6 +16,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -56,11 +58,14 @@ public class Member {
     private MarketingInfoStatus marketingInfoStatus;
 
     @Embedded
+    private ProfileImage profileImage;
+
+    @Embedded
     private CommonField commonField = new CommonField();
 
     @Builder
     public Member(final Long id, final Nickname nickname, final Gender gender, final Birthday birthday, final Mbti mbti,
-                  final SignUpStatus signUpStatus, final Authority authority,
+                  final SignUpStatus signUpStatus, final Authority authority, final ProfileImage profileImage,
                   final MarketingInfoStatus marketingInfoStatus) {
         this.id = id;
         this.nickname = nickname;
@@ -69,6 +74,7 @@ public class Member {
         this.mbti = mbti;
         this.signUpStatus = signUpStatus;
         this.authority = authority;
+        this.profileImage = profileImage;
         this.marketingInfoStatus = marketingInfoStatus;
     }
 
@@ -93,7 +99,25 @@ public class Member {
                 .build();
     }
 
+    public Member addNewProfileImages(final List<String> imageUrls) {
+        return Member.builder()
+                .id(id)
+                .nickname(nickname)
+                .gender(gender)
+                .birthday(birthday)
+                .mbti(mbti)
+                .signUpStatus(signUpStatus)
+                .authority(authority)
+                .profileImage(ProfileImage.from(imageUrls))
+                .marketingInfoStatus(marketingInfoStatus)
+                .build();
+    }
+
     public boolean isAlreadySignedUp() {
         return signUpStatus == SignUpStatus.SIGNED_UP;
+    }
+
+    public boolean hasAnyProfileImage() {
+        return profileImage != null;
     }
 }

--- a/src/main/java/com/project1hour/api/core/domain/member/profileinfo/ProfileImage.java
+++ b/src/main/java/com/project1hour/api/core/domain/member/profileinfo/ProfileImage.java
@@ -1,0 +1,59 @@
+package com.project1hour.api.core.domain.member.profileinfo;
+
+import static com.project1hour.api.core.domain.member.profileinfo.ProfileImageFiles.MAX_PROFILE_IMAGE_SIZE;
+
+import com.project1hour.api.global.advice.BadRequestException;
+import com.project1hour.api.global.advice.ErrorCode;
+import jakarta.persistence.Embeddable;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProfileImage {
+
+    private static final int FIRST_IMAGE_IDX = 0;
+    private static final int SECOND_IMAGE_IDX = 1;
+    private static final int THIRD_IMAGE_IDX = 2;
+    public static final int MIN_PROFILE_IMAGE_SIZE = 1;
+
+    private String firstProfileImageUrl;
+    private String secondProfileImageUrl;
+    private String thirdProfileImageUrl;
+
+    @Builder
+    public ProfileImage(final String firstProfileImageUrl, final String secondProfileImageUrl,
+                        final String thirdProfileImageUrl) {
+        this.firstProfileImageUrl = firstProfileImageUrl;
+        this.secondProfileImageUrl = secondProfileImageUrl;
+        this.thirdProfileImageUrl = thirdProfileImageUrl;
+    }
+
+    public static ProfileImage from(final List<String> imageUrls) {
+        validateSize(imageUrls);
+
+        ProfileImageBuilder builder = ProfileImage.builder();
+        if (imageUrls.size() == 1) {
+            builder.firstProfileImageUrl(imageUrls.get(FIRST_IMAGE_IDX));
+        }
+        if (imageUrls.size() == 2) {
+            builder.firstProfileImageUrl(imageUrls.get(SECOND_IMAGE_IDX));
+        }
+        if (imageUrls.size() == 3) {
+            builder.firstProfileImageUrl(imageUrls.get(THIRD_IMAGE_IDX));
+        }
+
+        return builder.build();
+    }
+
+    public static void validateSize(final List<String> imageUrls) {
+        if (imageUrls.isEmpty() || imageUrls.size() > MAX_PROFILE_IMAGE_SIZE) {
+            String message = String.format("프로필 이미지는 1장 이상 3장 이하여야 합니다. size = %d", imageUrls.size());
+            throw new BadRequestException(message, ErrorCode.INVALID_MEMBER_PROFILE_IMAGE_SIZE);
+        }
+    }
+}

--- a/src/main/java/com/project1hour/api/core/domain/member/profileinfo/ProfileImageFiles.java
+++ b/src/main/java/com/project1hour/api/core/domain/member/profileinfo/ProfileImageFiles.java
@@ -1,0 +1,29 @@
+package com.project1hour.api.core.domain.member.profileinfo;
+
+import com.project1hour.api.core.domain.image.ImageFile;
+import com.project1hour.api.global.advice.BadRequestException;
+import com.project1hour.api.global.advice.ErrorCode;
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public record ProfileImageFiles(List<MultipartFile> profileImageFiles) {
+
+    public static final int MAX_PROFILE_IMAGE_SIZE = 3;
+
+    public ProfileImageFiles {
+        validateSize(profileImageFiles);
+    }
+
+    private void validateSize(final List<MultipartFile> profileImageFiles) {
+        if (profileImageFiles.isEmpty() || profileImageFiles.size() > MAX_PROFILE_IMAGE_SIZE) {
+            String message = String.format("프로필 이미지는 1장 이상 3장 이하여야 합니다. size = %d", profileImageFiles.size());
+            throw new BadRequestException(message, ErrorCode.INVALID_MEMBER_PROFILE_IMAGE_SIZE);
+        }
+    }
+
+    public List<ImageFile> toImageFiles() {
+        return profileImageFiles.stream()
+                .map(ImageFile::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/project1hour/api/core/implement/image/ImageProcessor.java
+++ b/src/main/java/com/project1hour/api/core/implement/image/ImageProcessor.java
@@ -1,0 +1,22 @@
+package com.project1hour.api.core.implement.image;
+
+import com.project1hour.api.core.domain.image.ImageFile;
+import com.project1hour.api.core.domain.image.ImageUploader;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+@RequiredArgsConstructor
+public class ImageProcessor {
+
+    private final ImageUploader imageUploader;
+
+    public List<String> uploadImages(final List<MultipartFile> images) {
+        return images.stream()
+                .map(ImageFile::from)
+                .map(imageUploader::upload)
+                .toList();
+    }
+}

--- a/src/main/java/com/project1hour/api/core/implement/image/ImageProcessor.java
+++ b/src/main/java/com/project1hour/api/core/implement/image/ImageProcessor.java
@@ -1,7 +1,10 @@
 package com.project1hour.api.core.implement.image;
 
-import com.project1hour.api.core.domain.image.ImageFile;
 import com.project1hour.api.core.domain.image.ImageUploader;
+import com.project1hour.api.core.domain.member.Member;
+import com.project1hour.api.core.domain.member.profileinfo.ProfileImageFiles;
+import com.project1hour.api.global.advice.BadRequestException;
+import com.project1hour.api.global.advice.ErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -13,9 +16,15 @@ public class ImageProcessor {
 
     private final ImageUploader imageUploader;
 
-    public List<String> uploadImages(final List<MultipartFile> images) {
-        return images.stream()
-                .map(ImageFile::from)
+    public List<String> uploadProfileImages(final Member member, final List<MultipartFile> images) {
+        ProfileImageFiles profileImageFiles = new ProfileImageFiles(images);
+
+        if (member.hasAnyProfileImage()) {
+            throw new BadRequestException("이미 최초 프로필 등록을 완료했습니다.", ErrorCode.ALREADY_UPLOAD_NEW_PROFILE_IMAGE);
+        }
+
+        return profileImageFiles.toImageFiles()
+                .stream()
                 .map(imageUploader::upload)
                 .toList();
     }

--- a/src/main/java/com/project1hour/api/core/implement/member/MemberProcessor.java
+++ b/src/main/java/com/project1hour/api/core/implement/member/MemberProcessor.java
@@ -7,6 +7,7 @@ import com.project1hour.api.core.implement.auth.dto.SocialInfo;
 import com.project1hour.api.core.implement.member.dto.NewMemberInfo;
 import com.project1hour.api.global.advice.BadRequestException;
 import com.project1hour.api.global.advice.ErrorCode;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,5 +41,11 @@ public class MemberProcessor {
         );
 
         memberRepository.save(signedUpMember);
+    }
+
+    public void updateNewProfileImages(final Member member, final List<String> imageUrls) {
+        Member updatedMember = member.addNewProfileImages(imageUrls);
+
+        memberRepository.save(updatedMember);
     }
 }

--- a/src/main/java/com/project1hour/api/core/implement/member/MemberReader.java
+++ b/src/main/java/com/project1hour/api/core/implement/member/MemberReader.java
@@ -13,8 +13,8 @@ public class MemberReader {
 
     private final MemberRepository memberRepository;
 
-    public Member read(final Long authenticatedMemberId) {
-        return memberRepository.getById(authenticatedMemberId);
+    public Member read(final Long memberId) {
+        return memberRepository.getById(memberId);
     }
 
     public boolean isExistsNickname(final String nickname) {

--- a/src/main/java/com/project1hour/api/core/infrastructure/image/S3ImageUploader.java
+++ b/src/main/java/com/project1hour/api/core/infrastructure/image/S3ImageUploader.java
@@ -32,7 +32,7 @@ public class S3ImageUploader implements ImageUploader {
     public String upload(final ImageFile imageFile) {
         try {
             S3Resource resource = s3Template.upload(bucket, savePath + imageFile.randomName(),
-                    imageFile.getImageInputStream());
+                    imageFile.imageInputStream());
 
             return cdnUrl + resource.getFilename();
         } catch (S3Exception e) {

--- a/src/main/java/com/project1hour/api/core/infrastructure/image/S3ImageUploader.java
+++ b/src/main/java/com/project1hour/api/core/infrastructure/image/S3ImageUploader.java
@@ -1,0 +1,42 @@
+package com.project1hour.api.core.infrastructure.image;
+
+import com.project1hour.api.core.domain.image.ImageFile;
+import com.project1hour.api.core.domain.image.ImageUploader;
+import com.project1hour.api.global.advice.ErrorCode;
+import com.project1hour.api.global.advice.InfraStructureException;
+import io.awspring.cloud.s3.S3Exception;
+import io.awspring.cloud.s3.S3Resource;
+import io.awspring.cloud.s3.S3Template;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class S3ImageUploader implements ImageUploader {
+
+    private final String bucket;
+    private final String cdnUrl;
+    private final String savePath;
+    private final S3Template s3Template;
+
+    public S3ImageUploader(@Value("${spring.cloud.aws.s3.bucket}") final String bucket,
+                           @Value("${spring.cloud.aws.s3.cdn-url}") final String cdnUrl,
+                           @Value("${spring.cloud.aws.s3.save-path}") final String savePath,
+                           final S3Template s3Template) {
+        this.bucket = bucket;
+        this.cdnUrl = cdnUrl;
+        this.savePath = savePath;
+        this.s3Template = s3Template;
+    }
+
+    @Override
+    public String upload(final ImageFile imageFile) {
+        try {
+            S3Resource resource = s3Template.upload(bucket, savePath + imageFile.randomName(),
+                    imageFile.getImageInputStream());
+
+            return cdnUrl + resource.getFilename();
+        } catch (S3Exception e) {
+            throw new InfraStructureException("S3 버킷에 이미지를 업로드할 수 없습니다.", ErrorCode.CAN_NOT_UPLOAD_IMAGE_TO_S3);
+        }
+    }
+}

--- a/src/main/java/com/project1hour/api/core/presentation/image/ImageController.java
+++ b/src/main/java/com/project1hour/api/core/presentation/image/ImageController.java
@@ -1,0 +1,31 @@
+package com.project1hour.api.core.presentation.image;
+
+import com.project1hour.api.core.domain.image.ImageFile;
+import com.project1hour.api.core.domain.image.ImageUploader;
+import com.project1hour.api.core.presentation.image.dto.SavedImagesResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/images")
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final ImageUploader imageUploader;
+
+    @PostMapping("/upload")
+    public ResponseEntity<SavedImagesResponse> upload(@RequestPart final List<MultipartFile> images) {
+        List<String> imageUrls = images.stream()
+                .map(ImageFile::from)
+                .map(imageUploader::upload)
+                .toList();
+
+        return ResponseEntity.ok(new SavedImagesResponse(imageUrls));
+    }
+}

--- a/src/main/java/com/project1hour/api/core/presentation/image/dto/SavedImagesResponse.java
+++ b/src/main/java/com/project1hour/api/core/presentation/image/dto/SavedImagesResponse.java
@@ -1,0 +1,8 @@
+package com.project1hour.api.core.presentation.image.dto;
+
+import java.util.List;
+
+public record SavedImagesResponse(
+        List<String> imageUrls
+) {
+}

--- a/src/main/java/com/project1hour/api/core/presentation/member/MemberController.java
+++ b/src/main/java/com/project1hour/api/core/presentation/member/MemberController.java
@@ -4,16 +4,21 @@ import com.project1hour.api.core.application.member.MemberService;
 import com.project1hour.api.core.presentation.auth.Login;
 import com.project1hour.api.core.presentation.auth.MemberOnly;
 import com.project1hour.api.core.presentation.member.dto.DuplicatedNicknameResponse;
+import com.project1hour.api.core.presentation.member.dto.ProfileImagesResponse;
 import com.project1hour.api.core.presentation.member.dto.SignUpRequest;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +26,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
+
+    @GetMapping("/duplicate/{nickname}")
+    public ResponseEntity<DuplicatedNicknameResponse> isDuplicate(@Valid @PathVariable final String nickname) {
+        boolean isDuplicate = memberService.isDuplicate(nickname);
+        DuplicatedNicknameResponse response = new DuplicatedNicknameResponse(isDuplicate);
+        return ResponseEntity.ok(response);
+    }
 
     @PostMapping("/signup")
     @MemberOnly
@@ -31,10 +43,13 @@ public class MemberController {
                 .build();
     }
 
-    @GetMapping("/duplicate/{nickname}")
-    public ResponseEntity<DuplicatedNicknameResponse> isDuplicate(@Valid @PathVariable final String nickname) {
-        boolean isDuplicate = memberService.isDuplicate(nickname);
-        DuplicatedNicknameResponse response = new DuplicatedNicknameResponse(isDuplicate);
+    @PatchMapping("/upload-profile-images")
+    @MemberOnly
+    public ResponseEntity<ProfileImagesResponse> uploadProfileImages(@Login final Long memberId,
+                                                                     @RequestPart final List<MultipartFile> images) {
+        List<String> imageUrls = memberService.uploadProfileImages(memberId, images);
+        ProfileImagesResponse response = new ProfileImagesResponse(imageUrls);
+
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/project1hour/api/core/presentation/member/dto/ProfileImagesResponse.java
+++ b/src/main/java/com/project1hour/api/core/presentation/member/dto/ProfileImagesResponse.java
@@ -1,0 +1,8 @@
+package com.project1hour.api.core.presentation.member.dto;
+
+import java.util.List;
+
+public record ProfileImagesResponse(
+        List<String> imageUrls
+) {
+}

--- a/src/main/java/com/project1hour/api/global/advice/ErrorCode.java
+++ b/src/main/java/com/project1hour/api/global/advice/ErrorCode.java
@@ -16,9 +16,18 @@ public enum ErrorCode {
     INVALID_AGE_LIMIT("M004", "회원가입 시, 사용자가 올해 기준 법정 성인 연령이 아닌 경우"),
     INVALID_GENDER_VALUE("M005", "회원가입 시, 성별을 찾을 수 없는 경우 ('MALE', 'FEMALE' 만 가능)"),
     INVALID_MBTI_VALUE("M006", "회원가입 시, MBTI가 잘못 입력된 경우"),
+    INVALID_MEMBER_PROFILE_IMAGE_SIZE("M007", "프로필 사진 업로드시, 프로필 사진이 1개 이상 3가 이하가 아닌 경우"),
+    ALREADY_UPLOAD_NEW_PROFILE_IMAGE("M008", "프로필 사진 업로드시, 이미 최초 프로필 사진 등록을 완료한 경우(최초 회원가입 프로필 사진 등록)"),
 
     // Interest 관련
     INCLUDE_NOT_EXISTS_INTEREST("R001", "회원가입 시, 입력한 5개의 관심사 중에 존재하지 않는 관심사가 포함된 경우"),
+
+    // Image 관련
+    CAN_NOT_READ_IMAGE("IM00", "이미지 업로드시 이미지를 읽을 수 없는 경우"),
+    NULL_IMAGE("IM01", "이미지 업로드시, 이미지가 NULL인 경우"),
+    EMPTY_IMAGE("IM02", "이미지 업로드시, 이미지의 크기가 0인 경우"),
+    INVALID_IMAGE_NAME("IM03", "이미지 업로드시, 이미지의 이름이 비어있거나 NULL인 경우"),
+    INVALID_IMAGE_EXTENSION("IM04", "이미지 업로드시, PNG JPEG JPG SVG 확장자가 아닌 파일인 경우"),
 
     // Infrastructure 관련
     CAN_NOT_EXCHANGE_OAUTH_PROFILE("I000", "Oauth2 사용자의 프로필을 요청할 수 없는 경우(Provider 서버 예외)"),
@@ -26,6 +35,7 @@ public enum ErrorCode {
     UNSUPPORTED_TOKEN("I002", "JWT 검증 시, 토큰 형식이 JWT가 아닌 경우"),
     EXPIRED_TOKEN("I003", "JWT 검증 시, JWT 토큰이 만료된 경우"),
     MALFORMED_TOKEN("I004", "JWT 검증 시, 유효하지 않은 JWT 토큰인 경우"),
+    CAN_NOT_UPLOAD_IMAGE_TO_S3("I005", "이미지 업로드시, AWS S3에 이미지를 업로드할 수 없는 경우"),
 
     // Error
     INTERNAL_SERVER_ERROR("ER001", "예기치 못한 예외가 발생한 경우"),

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -19,6 +19,8 @@ spring:
     defer-datasource-initialization: true
   cloud:
     aws:
+      region:
+        static: ap-northeast-2
       credentials:
         access-key: DUMMYACCESSKEY
         secret-key: dummysecretkey

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -17,6 +17,16 @@ spring:
       hibernate:
         format_sql: true
     defer-datasource-initialization: true
+  cloud:
+    aws:
+      credentials:
+        access-key: DUMMYACCESSKEY
+        secret-key: dummysecretkey
+      s3:
+        bucket: test-bucket
+        region: ap-northeast-2
+        cdn-url: https://test.net/
+        save-path: image-test/
 
 logging:
   level:

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -465,11 +465,17 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <ul class="sectlevel2">
 <li><a href="#_회원가입">회원가입</a></li>
 <li><a href="#_닉네임_중복확인">닉네임 중복확인</a></li>
+<li><a href="#_회원_프로필_이미지_업로드">회원 프로필 이미지 업로드</a></li>
 </ul>
 </li>
 <li><a href="#interest">관심사</a>
 <ul class="sectlevel2">
 <li><a href="#_전체_관심사_조회">전체 관심사 조회</a></li>
+</ul>
+</li>
+<li><a href="#interest">이미지</a>
+<ul class="sectlevel2">
+<li><a href="#_이미지_업로드">이미지 업로드</a></li>
 </ul>
 </li>
 <li><a href="#error-code">에러 코드</a>
@@ -790,6 +796,86 @@ Content-Length: 26
 </table>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_회원_프로필_이미지_업로드"><a class="link" href="#_회원_프로필_이미지_업로드">회원 프로필 이미지 업로드</a></h3>
+<div class="sect3">
+<h4 id="_회원_프로필_이미지_업로드_http_request"><a class="link" href="#_회원_프로필_이미지_업로드_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/members/upload-profile-images HTTP/1.1
+Content-Type: application/json; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Type: application/json; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Authorization: Bearer jwt.token.here
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_회원_프로필_이미지_업로드_http_response"><a class="link" href="#_회원_프로필_이미지_업로드_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 82
+
+{
+  "imageUrls" : [ "https://cdn.net/7902d8b5-6da9-4182-a358-c87a7d5702d0.png" ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_회원_프로필_이미지_업로드_request_parts"><a class="link" href="#_회원_프로필_이미지_업로드_request_parts">Request parts</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Part</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>images</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">업로드할 프로필 이미지에 대한 MultipartFile</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_회원_프로필_이미지_업로드_response_fields"><a class="link" href="#_회원_프로필_이미지_업로드_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>imageUrls</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">저장된 Image Url</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -848,6 +934,101 @@ Content-Length: 106
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">관심사 이름</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="interest"><a class="link" href="#interest">이미지</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_이미지_업로드"><a class="link" href="#_이미지_업로드">이미지 업로드</a></h3>
+<div class="paragraph">
+<p>만약 특정 이미지 업로드 API가 존재하면 해당 API를 사용해주세요.</p>
+</div>
+<div class="sect3">
+<h4 id="_이미지_업로드_http_request"><a class="link" href="#_이미지_업로드_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/images/upload HTTP/1.1
+Content-Type: application/json; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Type: application/json; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Authorization: Bearer jwt.token.here
+Host: localhost:8080
+
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=images; filename=image14309266925213847578.jpg
+Content-Type: image/png
+
+Dummy Value
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_이미지_업로드_http_response"><a class="link" href="#_이미지_업로드_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 82
+
+{
+  "imageUrls" : [ "https://cdn.net/2839c398-920a-4430-9c5e-7d75bf8d0388.png" ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_이미지_업로드_request_parts"><a class="link" href="#_이미지_업로드_request_parts">Request parts</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Part</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>images</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">업로드할 이미지에 대한 MultipartFile</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_이미지_업로드_response_fields"><a class="link" href="#_이미지_업로드_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>imageUrls</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">저장된 Image Url</p></td>
 </tr>
 </tbody>
 </table>
@@ -917,8 +1098,36 @@ Content-Length: 106
 <td class="tableblock halign-left valign-top"><p class="tableblock">회원가입 시, MBTI가 잘못 입력된 경우</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>M007</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">프로필 사진 업로드시, 프로필 사진이 1개 이상 3가 이하가 아닌 경우</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>M008</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">프로필 사진 업로드시, 이미 최초 프로필 사진 등록을 완료한 경우(최초 회원가입 프로필 사진 등록)</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>R001</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">회원가입 시, 입력한 5개의 관심사 중에 존재하지 않는 관심사가 포함된 경우</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>IM00</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 업로드시 이미지를 읽을 수 없는 경우</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>IM01</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 업로드시, 이미지가 NULL인 경우</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>IM02</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 업로드시, 이미지의 크기가 0인 경우</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>IM03</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 업로드시, 이미지의 이름이 비어있거나 NULL인 경우</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>IM04</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 업로드시, PNG JPEG JPG SVG 확장자가 아닌 파일인 경우</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>I000</code></p></td>
@@ -941,6 +1150,10 @@ Content-Length: 106
 <td class="tableblock halign-left valign-top"><p class="tableblock">JWT 검증 시, 유효하지 않은 JWT 토큰인 경우</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>I005</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 업로드시, AWS S3에 이미지를 업로드할 수 없는 경우</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>ER001</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">예기치 못한 예외가 발생한 경우</p></td>
 </tr>
@@ -957,7 +1170,7 @@ Content-Length: 106
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-05-22 00:08:43 +0900
+Last updated 2024-06-01 03:25:44 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -819,7 +819,7 @@ Content-Type: application/json
 Content-Length: 82
 
 {
-  "imageUrls" : [ "https://cdn.net/7902d8b5-6da9-4182-a358-c87a7d5702d0.png" ]
+  "imageUrls" : [ "https://cdn.net/2e420085-5da5-467c-ae77-6135a9be091d.png" ]
 }</code></pre>
 </div>
 </div>
@@ -960,7 +960,7 @@ Authorization: Bearer jwt.token.here
 Host: localhost:8080
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Content-Disposition: form-data; name=images; filename=image14309266925213847578.jpg
+Content-Disposition: form-data; name=images; filename=image18400657102034655595.jpg
 Content-Type: image/png
 
 Dummy Value
@@ -977,7 +977,7 @@ Content-Type: application/json
 Content-Length: 82
 
 {
-  "imageUrls" : [ "https://cdn.net/2839c398-920a-4430-9c5e-7d75bf8d0388.png" ]
+  "imageUrls" : [ "https://cdn.net/f495617e-c130-4e6b-a4d3-fd41aba3a14b.png" ]
 }</code></pre>
 </div>
 </div>

--- a/src/test/java/com/project1hour/api/FakeImageGenerator.java
+++ b/src/test/java/com/project1hour/api/FakeImageGenerator.java
@@ -1,0 +1,20 @@
+package com.project1hour.api;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class FakeImageGenerator {
+
+    public static File createFakeImage() throws IOException {
+        File fakeImage = File.createTempFile("image", ".jpg");
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(fakeImage))) {
+            writer.write("Dummy Value");
+            writer.flush();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return fakeImage;
+    }
+}

--- a/src/test/java/com/project1hour/api/core/application/auth/AuthServiceTest.java
+++ b/src/test/java/com/project1hour/api/core/application/auth/AuthServiceTest.java
@@ -21,10 +21,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @Transactional
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class AuthServiceTest {

--- a/src/test/java/com/project1hour/api/core/application/interest/InterestServiceTest.java
+++ b/src/test/java/com/project1hour/api/core/application/interest/InterestServiceTest.java
@@ -10,9 +10,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @Transactional
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class InterestServiceTest {

--- a/src/test/java/com/project1hour/api/core/application/member/MemberServiceTest.java
+++ b/src/test/java/com/project1hour/api/core/application/member/MemberServiceTest.java
@@ -26,9 +26,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @Transactional
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class MemberServiceTest {

--- a/src/test/java/com/project1hour/api/core/documentation/DocumentationTest.java
+++ b/src/test/java/com/project1hour/api/core/documentation/DocumentationTest.java
@@ -8,7 +8,9 @@ import com.project1hour.api.core.application.interest.InterestService;
 import com.project1hour.api.core.application.member.MemberService;
 import com.project1hour.api.core.domain.auth.AuthenticatoinContext;
 import com.project1hour.api.core.domain.auth.TokenProvider;
+import com.project1hour.api.core.domain.image.ImageUploader;
 import com.project1hour.api.core.presentation.auth.AuthController;
+import com.project1hour.api.core.presentation.image.ImageController;
 import com.project1hour.api.core.presentation.interest.InterestController;
 import com.project1hour.api.core.presentation.member.MemberController;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
@@ -27,7 +29,8 @@ import org.springframework.web.context.WebApplicationContext;
 @WebMvcTest({
         AuthController.class,
         MemberController.class,
-        InterestController.class
+        InterestController.class,
+        ImageController.class
 })
 @ExtendWith(RestDocumentationExtension.class)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -43,6 +46,9 @@ public class DocumentationTest {
 
     @MockBean
     protected InterestService interestService;
+
+    @MockBean
+    protected ImageUploader imageUploader;
 
     @MockBean
     protected TokenProvider tokenProvider;

--- a/src/test/java/com/project1hour/api/core/documentation/ImageDocument.java
+++ b/src/test/java/com/project1hour/api/core/documentation/ImageDocument.java
@@ -1,18 +1,16 @@
 package com.project1hour.api.core.documentation;
 
+import static com.project1hour.api.FakeImageGenerator.createFakeImage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestPartFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 
 import com.project1hour.api.core.domain.member.Authority;
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.util.UUID;
 import org.junit.jupiter.api.Nested;
@@ -48,17 +46,6 @@ class ImageDocument extends DocumentationTest {
                             )
                     ))
                     .statusCode(HttpStatus.OK.value());
-        }
-
-        private static File createFakeImage() throws IOException {
-            File fakeImage = File.createTempFile("image", ".jpg");
-            try (BufferedWriter writer = new BufferedWriter(new FileWriter(fakeImage))) {
-                writer.write("Dummy Value");
-                writer.flush();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-            return fakeImage;
         }
     }
 }

--- a/src/test/java/com/project1hour/api/core/documentation/ImageDocument.java
+++ b/src/test/java/com/project1hour/api/core/documentation/ImageDocument.java
@@ -1,0 +1,64 @@
+package com.project1hour.api.core.documentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestPartFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+
+import com.project1hour.api.core.domain.member.Authority;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.UUID;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+class ImageDocument extends DocumentationTest {
+
+    @Nested
+    class 이미지_업로드 {
+
+        @Test
+        void 이미지를_업로드_할_수_있다() throws IOException {
+            File fakeImage = createFakeImage();
+            given(imageUploader.upload(any())).willReturn("https://cdn.net/" + UUID.randomUUID() + ".png");
+            given(tokenProvider.extractAuthority("jwt.token.here")).willReturn(Authority.MEMBER);
+            given(authenticatoinContext.getPrincipal()).willReturn("1");
+
+            docsGiven.contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer jwt.token.here")
+                    .multiPart("images", fakeImage, "image/png")
+                    .when().post("/api/images/upload")
+                    .then().log().all()
+                    .apply(document("image/upload/success",
+                            requestParts(
+                                    partWithName("images").description("업로드할 이미지에 대한 MultipartFile")
+                            ),
+                            responseFields(
+                                    fieldWithPath("imageUrls").type(JsonFieldType.ARRAY).description("저장된 Image Url")
+                            )
+                    ))
+                    .statusCode(HttpStatus.OK.value());
+        }
+
+        private static File createFakeImage() throws IOException {
+            File fakeImage = File.createTempFile("image", ".jpg");
+            try (BufferedWriter writer = new BufferedWriter(new FileWriter(fakeImage))) {
+                writer.write("Dummy Value");
+                writer.flush();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            return fakeImage;
+        }
+    }
+}

--- a/src/test/java/com/project1hour/api/core/documentation/MemberDocument.java
+++ b/src/test/java/com/project1hour/api/core/documentation/MemberDocument.java
@@ -1,5 +1,6 @@
 package com.project1hour.api.core.documentation;
 
+import static com.project1hour.api.FakeImageGenerator.createFakeImage;
 import static com.project1hour.api.core.documentation.DocumentFormatGenerator.getConstraints;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -9,12 +10,17 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 
 import com.project1hour.api.core.domain.member.Authority;
 import com.project1hour.api.core.presentation.member.dto.SignUpRequest;
+import java.io.File;
+import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
@@ -84,6 +90,35 @@ public class MemberDocument extends DocumentationTest {
                             pathParameters(parameterWithName("nickname").description("중복 검사할 닉네임")),
                             responseFields(
                                     fieldWithPath("isDuplicate").type(JsonFieldType.BOOLEAN).description("중복 여부"))
+                    ))
+                    .statusCode(HttpStatus.OK.value());
+        }
+    }
+
+    @Nested
+    class 회원_프로필_이미지_업로드 {
+
+        @Test
+        void 회원_프로필_이미지를_업로드_할_수_있다() throws IOException {
+            File fakeImage = createFakeImage();
+            given(memberService.uploadProfileImages(any(), any())).willReturn(
+                    List.of("https://cdn.net/" + UUID.randomUUID() + ".png"));
+            given(tokenProvider.extractSubject("jwt.token.here")).willReturn("1");
+            given(tokenProvider.extractAuthority("jwt.token.here")).willReturn(Authority.MEMBER);
+            given(authenticatoinContext.getPrincipal()).willReturn("1");
+
+            docsGiven.contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer jwt.token.here")
+                    .multiPart("images", fakeImage, "image/png")
+                    .when().patch("/api/members/upload-profile-images")
+                    .then().log().all()
+                    .apply(document("member/upload-profile-images/success",
+                            requestParts(
+                                    partWithName("images").description("업로드할 프로필 이미지에 대한 MultipartFile")
+                            ),
+                            responseFields(
+                                    fieldWithPath("imageUrls").type(JsonFieldType.ARRAY).description("저장된 Image Url")
+                            )
                     ))
                     .statusCode(HttpStatus.OK.value());
         }

--- a/src/test/java/com/project1hour/api/core/domain/image/ImageFileTest.java
+++ b/src/test/java/com/project1hour/api/core/domain/image/ImageFileTest.java
@@ -1,0 +1,58 @@
+package com.project1hour.api.core.domain.image;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.project1hour.api.global.advice.BadRequestException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.util.StringUtils;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ImageFileTest {
+
+    @Test
+    void 이미지_파일이_NULL이라면_예외가_발생한다() {
+        // expect
+        assertThatThrownBy(() -> ImageFile.from(null))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("이미지로 NULL값이 들어올 수 없습니다.");
+    }
+
+    @Test
+    void 이미지_파일이_비어있다면_예외가_발생한다() {
+        // given
+        MockMultipartFile file = new MockMultipartFile("name", new byte[0]);
+
+        // expect
+        assertThatThrownBy(() -> ImageFile.from(file))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("이미지 파일이 비어있을 수 없습니다.");
+    }
+
+    @Test
+    void 이미지_파일의_이름이_비어있으면_예외가_발생한다() {
+        // given
+        MockMultipartFile file = new MockMultipartFile(" ", new byte[10]);
+
+        // expect
+        assertThatThrownBy(() -> ImageFile.from(file))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("이미지의 이름이 NULL이거나 비어있을 수 없습니다.");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"image.gif", "image.webp", "image.dummy"})
+    void 지원하지_않는_이미지_확장자라면_예외가_발생한다(String originalFileName) {
+        // given
+        MockMultipartFile file = new MockMultipartFile("name", originalFileName, "image", originalFileName.getBytes());
+
+        // expect
+        assertThatThrownBy(() -> ImageFile.from(file))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("불가능한 이미지 확장자 입니다. extension = " + StringUtils.getFilenameExtension(originalFileName));
+    }
+}

--- a/src/test/java/com/project1hour/api/core/domain/image/ImageFileTest.java
+++ b/src/test/java/com/project1hour/api/core/domain/image/ImageFileTest.java
@@ -25,7 +25,7 @@ class ImageFileTest {
     @Test
     void 이미지_파일이_비어있다면_예외가_발생한다() {
         // given
-        MockMultipartFile file = new MockMultipartFile("name", new byte[0]);
+        MockMultipartFile file = new MockMultipartFile("name1", "image1.jpg", "image/jpg", new byte[0]);
 
         // expect
         assertThatThrownBy(() -> ImageFile.from(file))
@@ -36,7 +36,7 @@ class ImageFileTest {
     @Test
     void 이미지_파일의_이름이_비어있으면_예외가_발생한다() {
         // given
-        MockMultipartFile file = new MockMultipartFile(" ", new byte[10]);
+        MockMultipartFile file = new MockMultipartFile("image1", "", "image/jpg", new byte[10]);
 
         // expect
         assertThatThrownBy(() -> ImageFile.from(file))
@@ -48,11 +48,13 @@ class ImageFileTest {
     @ValueSource(strings = {"image.gif", "image.webp", "image.dummy"})
     void 지원하지_않는_이미지_확장자라면_예외가_발생한다(String originalFileName) {
         // given
-        MockMultipartFile file = new MockMultipartFile("name", originalFileName, "image", originalFileName.getBytes());
+        String extension = StringUtils.getFilenameExtension(originalFileName);
+        MockMultipartFile file = new MockMultipartFile("name", originalFileName, "image/" + extension,
+                originalFileName.getBytes());
 
         // expect
         assertThatThrownBy(() -> ImageFile.from(file))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("불가능한 이미지 확장자 입니다. extension = " + StringUtils.getFilenameExtension(originalFileName));
+                .hasMessage("불가능한 이미지 확장자 입니다. extension = " + extension);
     }
 }

--- a/src/test/java/com/project1hour/api/core/domain/member/profileinfo/ProfileImageFilesTest.java
+++ b/src/test/java/com/project1hour/api/core/domain/member/profileinfo/ProfileImageFilesTest.java
@@ -1,0 +1,52 @@
+package com.project1hour.api.core.domain.member.profileinfo;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ProfileImageFilesTest {
+
+    @Test
+    void 프로필_이미지_파일을_생성할_수_있다() {
+        // expect
+        assertThatNoException().isThrownBy(
+                () -> new ProfileImageFiles(List.of(
+                        new MockMultipartFile("name1", "image1.jpg", "image/jpg", new byte[10]),
+                        new MockMultipartFile("name2", "image2.jpg", "image/jpg", new byte[10]),
+                        new MockMultipartFile("name3", "image3.jpg", "image/jpg", new byte[10])))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getProfileImageUrls")
+    void 프로필_이미지_파일이_없거나_3장을_넘기면_예외가_발생한다(List<MultipartFile> profileImageUrls) {
+        // expect
+        assertThatThrownBy(() -> new ProfileImageFiles(profileImageUrls));
+    }
+
+    private static Stream<Arguments> getProfileImageUrls() {
+        return Stream.of(
+                Arguments.arguments(Collections.emptyList()),
+                Arguments.arguments(
+                        List.of(
+                                new MockMultipartFile("name1", "image1.jpg", "image/jpg", new byte[10]),
+                                new MockMultipartFile("name2", "image2.jpg", "image/jpg", new byte[10]),
+                                new MockMultipartFile("name3", "image3.jpg", "image/jpg", new byte[10]),
+                                new MockMultipartFile("name4", "image4.jpg", "image/jpg", new byte[10])
+                        )
+                )
+        );
+    }
+}

--- a/src/test/java/com/project1hour/api/core/domain/member/profileinfo/ProfileImageTest.java
+++ b/src/test/java/com/project1hour/api/core/domain/member/profileinfo/ProfileImageTest.java
@@ -1,0 +1,41 @@
+package com.project1hour.api.core.domain.member.profileinfo;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ProfileImageTest {
+
+    @Test
+    void 프로필_이미지를_생성할_수_있다() {
+        // expect
+        assertThatNoException().isThrownBy(() -> ProfileImage.from(
+                List.of("https://cdn.net/image1.png", "https://cdn.net/image2.png", "https://cdn.net/image3.png")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getProfileImageUrls")
+    void 프로필_이미지가_없거나_3장을_넘기면_예외가_발생한다(List<String> profileImageUrls) {
+        // expect
+        assertThatThrownBy(() -> ProfileImage.from(profileImageUrls));
+    }
+
+    private static Stream<Arguments> getProfileImageUrls() {
+        return Stream.of(
+                Arguments.arguments(Collections.emptyList()),
+                Arguments.arguments(List.of("https://cdn.net/image1.png", "https://cdn.net/image2.png",
+                        "https://cdn.net/image3.png", "https://cdn.net/image4.png"))
+        );
+    }
+
+}

--- a/src/test/java/com/project1hour/api/core/implement/auth/SocialProfileReaderTest.java
+++ b/src/test/java/com/project1hour/api/core/implement/auth/SocialProfileReaderTest.java
@@ -8,8 +8,9 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class SocialProfileReaderTest {
 

--- a/src/test/java/com/project1hour/api/core/infrastructure/auth/kakao/KakaoOauthClientTest.java
+++ b/src/test/java/com/project1hour/api/core/infrastructure/auth/kakao/KakaoOauthClientTest.java
@@ -3,6 +3,7 @@ package com.project1hour.api.core.infrastructure.auth.kakao;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
@@ -27,7 +28,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class KakaoOauthClientTest {
 

--- a/src/test/java/com/project1hour/api/core/infrastructure/image/S3ImageUploaderTest.java
+++ b/src/test/java/com/project1hour/api/core/infrastructure/image/S3ImageUploaderTest.java
@@ -1,0 +1,49 @@
+package com.project1hour.api.core.infrastructure.image;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.project1hour.api.core.domain.image.ImageFile;
+import com.project1hour.api.core.domain.image.ImageUploader;
+import com.project1hour.api.global.advice.InfraStructureException;
+import io.awspring.cloud.s3.S3Exception;
+import io.awspring.cloud.s3.S3Template;
+import java.io.ByteArrayInputStream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class S3ImageUploaderTest {
+
+    @Autowired
+    private ImageUploader imageUploader;
+
+    @MockBean
+    private S3Template s3Template;
+
+    @Nested
+    class upload_메소드는 {
+
+        @Test
+        void S3에_이미지를_업로드할_수_없으면_예외가_발생한다() {
+            // given
+            given(s3Template.upload(any(), any(), any())).willThrow(S3Exception.class);
+            ImageFile imageFile = new ImageFile("image.png", "image/png", "png",
+                    new ByteArrayInputStream("image.png".getBytes()));
+
+            // expect
+            assertThatThrownBy(() -> imageUploader.upload(imageFile))
+                    .isInstanceOf(InfraStructureException.class)
+                    .hasMessage("S3 버킷에 이미지를 업로드할 수 없습니다.");
+
+        }
+    }
+}


### PR DESCRIPTION
## 📄 Summary

`REFACTORING` (리팩토링 될 여지 있음)

- 새로운 프로필 이미지 업로드 플로우
    1. 사용자 소셜 로그인 (`POST api/auth/{provider}`)
    2. 사용자가 회원가입을 함 (`POST /api/members/signup`)
    3. 최초 프로필 사진 등록 요청 (`PATCH api/members/upload-profile-images`)
    4. 프로필 이미지가 등록됨
- 이미 프로필 이미지가 업로드가 되어있는 상태라면
    - 예외 발생(fast fail) → S3업로드 X
- 업로드할 사진의 개수가 1 ~ 3개 사이가 아니라면
    - 예외 발생(fast fail) → S3업로드 X


## 🙋🏻 More




close #13