### PR TITLE
fix: 법정 성인 기준년도 계산식을 수정

### DIFF
--- a/src/main/java/com/project1hour/api/core/domain/member/profileinfo/Birthday.java
+++ b/src/main/java/com/project1hour/api/core/domain/member/profileinfo/Birthday.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 public class Birthday {
 
     private static LocalDate MINIMUM_ADULT_BIRTH = LocalDate.of(
-            LocalDate.now().minusYears(9).getYear(),
+            LocalDate.now().minusYears(19).getYear(),
             LocalDate.MAX.getMonth(),
             LocalDate.MAX.getDayOfMonth()
     );

--- a/src/test/java/com/project1hour/api/core/application/member/MemberServiceTest.java
+++ b/src/test/java/com/project1hour/api/core/application/member/MemberServiceTest.java
@@ -159,7 +159,7 @@ class MemberServiceTest {
         class 가입시_법정_성인_연령이_아니라면 {
 
             private static LocalDate MINIMUM_ADULT_BIRTH = LocalDate.of(
-                    LocalDate.now().minusYears(9).getYear(),
+                    LocalDate.now().minusYears(19).getYear(),
                     LocalDate.MAX.getMonth(),
                     LocalDate.MAX.getDayOfMonth()
             );

--- a/src/test/java/com/project1hour/api/core/domain/member/profileinfo/BirthdayTest.java
+++ b/src/test/java/com/project1hour/api/core/domain/member/profileinfo/BirthdayTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 class BirthdayTest {
 
     private static LocalDate MINIMUM_ADULT_BIRTH = LocalDate.of(
-            LocalDate.now().minusYears(9).getYear(),
+            LocalDate.now().minusYears(19).getYear(),
             LocalDate.MAX.getMonth(),
             LocalDate.MAX.getDayOfMonth()
     );


### PR DESCRIPTION
## 📄 Summary

- 현재년도 기준 19년을 빼야 하는데 9년을 뺌.. 실수 ㅠ

## 🙋🏻 More



close #member-birthday-validate