### PR TITLE
feat: 재화 사용 여부 확인을 위한 필터링 로직 구현

### DIFF
--- a/src/docs/asciidoc/credit.adoc
+++ b/src/docs/asciidoc/credit.adoc
@@ -1,0 +1,7 @@
+[[credit]]
+
+== 재화
+
+=== 사용 가능한 재화 체크
+
+operation::credit/count-check/success[snippets='http-request,http-response,response-fields']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -10,5 +10,6 @@
 include::auth.adoc[]
 include::member.adoc[]
 include::interest.adoc[]
+include::credit.adoc[]
 include::image.adoc[]
 include::errorCode.adoc[]

--- a/src/main/java/com/project1hour/api/core/application/credit/CreditService.java
+++ b/src/main/java/com/project1hour/api/core/application/credit/CreditService.java
@@ -1,0 +1,19 @@
+package com.project1hour.api.core.application.credit;
+
+import com.project1hour.api.core.domain.credit.Credit;
+import com.project1hour.api.core.implement.credit.CreditReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CreditService {
+
+    private final CreditReader creditReader;
+
+    public boolean canUseCredit(final Long memberId, final int creditCount) {
+        Credit credit = creditReader.read(memberId);
+
+        return credit.hasMoreCredit(creditCount);
+    }
+}

--- a/src/main/java/com/project1hour/api/core/domain/credit/Credit.java
+++ b/src/main/java/com/project1hour/api/core/domain/credit/Credit.java
@@ -57,4 +57,8 @@ public class Credit {
                 .member(member)
                 .build();
     }
+
+    public boolean hasMoreCredit(int creditCount) {
+        return this.creditCount >= creditCount;
+    }
 }

--- a/src/main/java/com/project1hour/api/core/domain/credit/CreditRepository.java
+++ b/src/main/java/com/project1hour/api/core/domain/credit/CreditRepository.java
@@ -1,6 +1,10 @@
 package com.project1hour.api.core.domain.credit;
 
+import java.util.Optional;
+
 public interface CreditRepository {
 
     Credit save(Credit credit);
+
+    Optional<Credit> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/project1hour/api/core/implement/credit/CreditReader.java
+++ b/src/main/java/com/project1hour/api/core/implement/credit/CreditReader.java
@@ -1,0 +1,20 @@
+package com.project1hour.api.core.implement.credit;
+
+import com.project1hour.api.core.domain.credit.Credit;
+import com.project1hour.api.core.domain.credit.CreditRepository;
+import com.project1hour.api.global.advice.BadRequestException;
+import com.project1hour.api.global.advice.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CreditReader {
+
+    private final CreditRepository creditRepository;
+
+    public Credit read(Long memberId) {
+        return creditRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new BadRequestException("현재 사용자의 크레딧을 찾을 수 없습니다.", ErrorCode.CREDIT_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/project1hour/api/core/infrastructure/credit/CoreCreditRepository.java
+++ b/src/main/java/com/project1hour/api/core/infrastructure/credit/CoreCreditRepository.java
@@ -2,6 +2,7 @@ package com.project1hour.api.core.infrastructure.credit;
 
 import com.project1hour.api.core.domain.credit.Credit;
 import com.project1hour.api.core.domain.credit.CreditRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -14,5 +15,10 @@ public class CoreCreditRepository implements CreditRepository {
     @Override
     public Credit save(final Credit credit) {
         return jpaCreditRepository.save(credit);
+    }
+
+    @Override
+    public Optional<Credit> findByMemberId(Long memberId) {
+        return jpaCreditRepository.findByMemberId(memberId);
     }
 }

--- a/src/main/java/com/project1hour/api/core/infrastructure/credit/JpaCreditRepository.java
+++ b/src/main/java/com/project1hour/api/core/infrastructure/credit/JpaCreditRepository.java
@@ -1,7 +1,10 @@
 package com.project1hour.api.core.infrastructure.credit;
 
 import com.project1hour.api.core.domain.credit.Credit;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaCreditRepository extends JpaRepository<Credit, Long> {
+
+    Optional<Credit> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/project1hour/api/core/presentation/auth/AuthController.java
+++ b/src/main/java/com/project1hour/api/core/presentation/auth/AuthController.java
@@ -13,8 +13,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/api")
+@RequiredArgsConstructor
 public class AuthController {
 
     private final AuthService authService;

--- a/src/main/java/com/project1hour/api/core/presentation/credit/CreditController.java
+++ b/src/main/java/com/project1hour/api/core/presentation/credit/CreditController.java
@@ -1,0 +1,29 @@
+package com.project1hour.api.core.presentation.credit;
+
+import com.project1hour.api.core.application.credit.CreditService;
+import com.project1hour.api.core.presentation.auth.Login;
+import com.project1hour.api.core.presentation.credit.dto.CreditCheckRequest;
+import com.project1hour.api.core.presentation.credit.dto.CreditCheckResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/credits")
+@RequiredArgsConstructor
+public class CreditController {
+
+    private final CreditService creditService;
+
+    @PostMapping("/check")
+    public ResponseEntity<CreditCheckResponse> checkCredit(@Login final Long memberId,
+                                                           @RequestBody final CreditCheckRequest request) {
+        boolean result = creditService.canUseCredit(memberId, request.creditCount());
+        CreditCheckResponse response = new CreditCheckResponse(result);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/project1hour/api/core/presentation/credit/dto/CreditCheckRequest.java
+++ b/src/main/java/com/project1hour/api/core/presentation/credit/dto/CreditCheckRequest.java
@@ -1,0 +1,6 @@
+package com.project1hour.api.core.presentation.credit.dto;
+
+public record CreditCheckRequest(
+        int creditCount
+) {
+}

--- a/src/main/java/com/project1hour/api/core/presentation/credit/dto/CreditCheckResponse.java
+++ b/src/main/java/com/project1hour/api/core/presentation/credit/dto/CreditCheckResponse.java
@@ -1,0 +1,6 @@
+package com.project1hour.api.core.presentation.credit.dto;
+
+public record CreditCheckResponse(
+        boolean canUse
+) {
+}

--- a/src/main/java/com/project1hour/api/core/presentation/interest/InterestController.java
+++ b/src/main/java/com/project1hour/api/core/presentation/interest/InterestController.java
@@ -10,8 +10,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/api")
+@RequiredArgsConstructor
 public class InterestController {
 
     @GetMapping("/interests")

--- a/src/main/java/com/project1hour/api/core/presentation/member/MemberController.java
+++ b/src/main/java/com/project1hour/api/core/presentation/member/MemberController.java
@@ -21,8 +21,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/api/members")
+@RequiredArgsConstructor
 public class MemberController {
 
     private final MemberService memberService;

--- a/src/main/java/com/project1hour/api/global/advice/ErrorCode.java
+++ b/src/main/java/com/project1hour/api/global/advice/ErrorCode.java
@@ -20,6 +20,9 @@ public enum ErrorCode {
     INVALID_MEMBER_PROFILE_IMAGE_SIZE("M007", "프로필 사진 업로드시, 프로필 사진이 1개 이상 3가 이하가 아닌 경우"),
     ALREADY_UPLOAD_NEW_PROFILE_IMAGE("M008", "프로필 사진 업로드시, 이미 최초 프로필 사진 등록을 완료한 경우(최초 회원가입 프로필 사진 등록)"),
 
+    // Credit 관련
+    CREDIT_NOT_FOUND("C000", "Credit 조회 시, 특정 사용자의 Credit정보를 찾을 수 없는 경우"),
+
     // Interest 관련
     INCLUDE_NOT_EXISTS_INTEREST("R001", "회원가입 시, 입력한 5개의 관심사 중에 존재하지 않는 관심사가 포함된 경우"),
 

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -473,6 +473,11 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_전체_관심사_조회">전체 관심사 조회</a></li>
 </ul>
 </li>
+<li><a href="#credit">재화</a>
+<ul class="sectlevel2">
+<li><a href="#_사용_가능한_재화_체크">사용 가능한 재화 체크</a></li>
+</ul>
+</li>
 <li><a href="#interest">이미지</a>
 <ul class="sectlevel2">
 <li><a href="#_이미지_업로드">이미지 업로드</a></li>
@@ -819,7 +824,7 @@ Content-Type: application/json
 Content-Length: 82
 
 {
-  "imageUrls" : [ "https://cdn.net/d65c7af4-5010-4ce0-a4b3-adf0b1be2747.png" ]
+  "imageUrls" : [ "https://cdn.net/ca7f2b47-8e30-4d4a-822a-c58041e80741.png" ]
 }</code></pre>
 </div>
 </div>
@@ -942,6 +947,75 @@ Content-Length: 366
 </div>
 </div>
 <div class="sect1">
+<h2 id="credit"><a class="link" href="#credit">재화</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_사용_가능한_재화_체크"><a class="link" href="#_사용_가능한_재화_체크">사용 가능한 재화 체크</a></h3>
+<div class="sect3">
+<h4 id="_사용_가능한_재화_체크_http_request"><a class="link" href="#_사용_가능한_재화_체크_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/credits/check HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: Bearer jwt.token.here
+Content-Length: 23
+Host: localhost:8080
+
+{
+  "creditCount" : 6
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_사용_가능한_재화_체크_http_response"><a class="link" href="#_사용_가능한_재화_체크_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 21
+
+{
+  "canUse" : true
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_사용_가능한_재화_체크_response_fields"><a class="link" href="#_사용_가능한_재화_체크_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>canUse</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">해당 사용자가 입력받은 재화를 사용가능한지 여부(true:가능, false:불가능</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
 <h2 id="interest"><a class="link" href="#interest">이미지</a></h2>
 <div class="sectionbody">
 <div class="sect2">
@@ -960,7 +1034,7 @@ Authorization: Bearer jwt.token.here
 Host: localhost:8080
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Content-Disposition: form-data; name=images; filename=image7470390871560753536.jpg
+Content-Disposition: form-data; name=images; filename=image5011679966270450135.jpg
 Content-Type: image/png
 
 Dummy Value
@@ -977,7 +1051,7 @@ Content-Type: application/json
 Content-Length: 82
 
 {
-  "imageUrls" : [ "https://cdn.net/3c9c2609-ae48-4576-9a29-894e590d8829.png" ]
+  "imageUrls" : [ "https://cdn.net/283f160d-ce8b-436c-8307-cc3f58e3ba1f.png" ]
 }</code></pre>
 </div>
 </div>
@@ -1110,6 +1184,10 @@ Content-Length: 82
 <td class="tableblock halign-left valign-top"><p class="tableblock">프로필 사진 업로드시, 이미 최초 프로필 사진 등록을 완료한 경우(최초 회원가입 프로필 사진 등록)</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>C000</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Credit 조회 시, 특정 사용자의 Credit정보를 찾을 수 없는 경우</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>R001</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">회원가입 시, 입력한 5개의 관심사 중에 존재하지 않는 관심사가 포함된 경우</p></td>
 </tr>
@@ -1174,7 +1252,7 @@ Content-Length: 82
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-06-02 18:04:28 +0900
+Last updated 2024-06-25 01:56:31 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/project1hour/api/core/application/credit/CreditServiceTest.java
+++ b/src/test/java/com/project1hour/api/core/application/credit/CreditServiceTest.java
@@ -1,0 +1,88 @@
+package com.project1hour.api.core.application.credit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
+
+import com.project1hour.api.core.domain.auth.AuthenticationContext;
+import com.project1hour.api.core.domain.credit.Credit;
+import com.project1hour.api.core.domain.credit.CreditRepository;
+import com.project1hour.api.core.domain.member.Authority;
+import com.project1hour.api.core.domain.member.Member;
+import com.project1hour.api.core.domain.member.MemberRepository;
+import com.project1hour.api.core.domain.member.SignUpStatus;
+import com.project1hour.api.core.domain.member.profileinfo.Gender;
+import com.project1hour.api.core.domain.member.profileinfo.Nickname;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest(webEnvironment = NONE)
+@Transactional
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CreditServiceTest {
+
+    @Autowired
+    private CreditService creditService;
+
+    @Autowired
+    private CreditRepository creditRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @MockBean
+    private AuthenticationContext authenticationContext;
+
+    @Nested
+    class canUseCredit_메소드는 {
+
+        private Long memberId;
+
+        @BeforeEach
+        void setUp() {
+            Member member = Member.builder()
+                    .nickname(new Nickname("닉네임"))
+                    .gender(Gender.MALE)
+                    .authority(Authority.MEMBER)
+                    .signUpStatus(SignUpStatus.SIGNED_UP)
+                    .build();
+            memberRepository.save(member);
+            Credit credit = Credit.createWelcomeCredit(member);
+
+            creditRepository.save(credit);
+            memberId = member.getId();
+        }
+
+        @Nested
+        class 사용자가_가진_재화보다_많은_재화가_들어오면 {
+
+            @Test
+            void false를_반환한다() {
+                // when
+                boolean result = creditService.canUseCredit(memberId, 7);
+
+                // then
+                assertThat(result).isFalse();
+            }
+        }
+
+        @Nested
+        class 사용자가_가진_재화보다_작거나_같은_재화가_들어오면 {
+
+            @Test
+            void true를_반환한다() {
+                // when
+                boolean result = creditService.canUseCredit(memberId, 6);
+
+                // then
+                assertThat(result).isTrue();
+            }
+        }
+    }
+}

--- a/src/test/java/com/project1hour/api/core/documentation/CreditDocument.java
+++ b/src/test/java/com/project1hour/api/core/documentation/CreditDocument.java
@@ -1,0 +1,51 @@
+package com.project1hour.api.core.documentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+import com.project1hour.api.core.domain.member.Authority;
+import com.project1hour.api.core.presentation.credit.dto.CreditCheckRequest;
+import java.io.IOException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+public class CreditDocument extends DocumentationTest {
+
+    @Nested
+    class 사용가능_재화_확인 {
+
+        @Test
+        void 사용자가_특정_갯수의_재화를_사용할_수_있는지_확인한다() throws IOException {
+            CreditCheckRequest request = new CreditCheckRequest(6);
+            given(creditService.canUseCredit(any(), anyInt())).willReturn(true);
+            given(tokenProvider.extractSubject("jwt.token.here")).willReturn("1");
+            given(tokenProvider.extractAuthority("jwt.token.here")).willReturn(Authority.MEMBER);
+            given(authenticationContext.getPrincipal()).willReturn("1");
+
+            docsGiven.contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer jwt.token.here")
+                    .body(request)
+                    .when().post("/api/credits/check")
+                    .then().log().all()
+                    .apply(document("credit/count-check/success",
+                            requestFields(
+                                    fieldWithPath("creditCount").type(JsonFieldType.NUMBER).description("사용할 재화의 갯수")
+                            ),
+                            responseFields(
+                                    fieldWithPath("canUse").type(JsonFieldType.BOOLEAN)
+                                            .description("해당 사용자가 입력받은 재화를 사용가능한지 여부(true:가능, false:불가능")
+                            )
+                    ))
+                    .statusCode(HttpStatus.OK.value());
+        }
+    }
+}

--- a/src/test/java/com/project1hour/api/core/documentation/DocumentationTest.java
+++ b/src/test/java/com/project1hour/api/core/documentation/DocumentationTest.java
@@ -4,11 +4,13 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 
 import com.project1hour.api.core.application.auth.AuthService;
+import com.project1hour.api.core.application.credit.CreditService;
 import com.project1hour.api.core.application.member.MemberService;
 import com.project1hour.api.core.domain.auth.AuthenticationContext;
 import com.project1hour.api.core.domain.auth.TokenProvider;
 import com.project1hour.api.core.domain.image.ImageUploader;
 import com.project1hour.api.core.presentation.auth.AuthController;
+import com.project1hour.api.core.presentation.credit.CreditController;
 import com.project1hour.api.core.presentation.image.ImageController;
 import com.project1hour.api.core.presentation.interest.InterestController;
 import com.project1hour.api.core.presentation.member.MemberController;
@@ -29,7 +31,8 @@ import org.springframework.web.context.WebApplicationContext;
         AuthController.class,
         MemberController.class,
         InterestController.class,
-        ImageController.class
+        ImageController.class,
+        CreditController.class
 })
 @ExtendWith(RestDocumentationExtension.class)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -42,6 +45,9 @@ public class DocumentationTest {
 
     @MockBean
     protected MemberService memberService;
+
+    @MockBean
+    protected CreditService creditService;
 
     @MockBean
     protected ImageUploader imageUploader;

--- a/src/test/java/com/project1hour/api/core/domain/credit/CreditTest.java
+++ b/src/test/java/com/project1hour/api/core/domain/credit/CreditTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 class CreditTest {
 
     @Test
-    void 웰컴_크레딧을_받을_수_있다() {
+    void 웰컴_재화를_받을_수_있다() {
         // given
         Member member = Member.builder()
                 .build();
@@ -20,5 +20,33 @@ class CreditTest {
 
         // then
         assertThat(welcomeCredit.getCreditCount()).isEqualTo(6);
+    }
+
+    @Test
+    void hasMoreCredit_메소드는_기존_재화_개수보다_크다면_false를_반환한다() {
+        // given
+        Credit credit = Credit.builder()
+                .creditCount(5)
+                .build();
+
+        // when
+        boolean hasMoreCredit = credit.hasMoreCredit(6);
+
+        // then
+        assertThat(hasMoreCredit).isFalse();
+    }
+
+    @Test
+    void hasMoreCredit메소드는_기존_재화_개수보다_작거나_같다면_true를_반환한다() {
+        // given
+        Credit credit = Credit.builder()
+                .creditCount(5)
+                .build();
+
+        // when
+        boolean hasMoreCredit = credit.hasMoreCredit(5);
+
+        // then
+        assertThat(hasMoreCredit).isTrue();
     }
 }


### PR DESCRIPTION
## 📄 Summary
- 단순하게 재화 개수를 입력받아, 사용자가 가진 실제 재화 갯수와 비교해 boolean 결과를 반환합니다.
- 재화 체크 API 추가 (`POST api/credits/check`)

## 🙋🏻 More

>


close #38